### PR TITLE
update api-client to 2.25.0

### DIFF
--- a/overops-functions/build.gradle
+++ b/overops-functions/build.gradle
@@ -29,8 +29,8 @@ dependencies {
 		println "Compiling overops functions with maven api-client"
 
 		compile (
-			"com.takipi:api-client:2.18.0",
-			"com.takipi:api-client-util:2.18.0",
+			"com.takipi:api-client:2.25.0",
+			"com.takipi:api-client-util:2.25.0",
 		)
 	}
 }


### PR DESCRIPTION
build fails with the older API client